### PR TITLE
Add harmony-ecs

### DIFF
--- a/libraries/index.js
+++ b/libraries/index.js
@@ -13,3 +13,4 @@ export { default as GoodluckLibrary } from './lib-goodluck';
 export { default as PicoesLibrary } from './lib-picoes';
 export { default as WolfEcsLibrary } from './lib-wolf-ecs';
 export { default as PiecsLibrary } from './lib-piecs';
+export { default as HarmonyEcsLibrary } from './lib-harmony-ecs';

--- a/libraries/lib-harmony-ecs.js
+++ b/libraries/lib-harmony-ecs.js
@@ -1,0 +1,57 @@
+import { World, Schema, Entity, Query, formats } from 'harmony-ecs';
+
+const Vector2 = { x: formats.float32, y: formats.float32 };
+
+export default {
+    name: 'harmony-ecs',
+    setup() {
+        this.updateCount = 0;
+        this.world = World.make(1e6);
+        this.Position = Schema.makeBinary(this.world, Vector2);
+        this.Velocity = Schema.makeBinary(this.world, Vector2);
+        this.query = Query.make(this.world, [this.Position, this.Velocity]);
+    },
+
+    createEntity() {
+        return Entity.make(this.world);
+    },
+
+    addPositionComponent(id) {
+        Entity.set(this.world, id, [this.Position], [{ x: 100, y: 100 }]);
+    },
+
+    addVelocityComponent(id) {
+        Entity.set(this.world, id, [this.Velocity], [{ x: 1.2, y: 1.7 }]);
+    },
+
+    removePositionComponent(id) {
+        Entity.unset(this.world, id, [this.Position]);
+    },
+
+    removeVelocityComponent(id) {
+        Entity.unset(this.world, id, [this.Velocity]);
+    },
+
+    destroyEntity(id) {
+        Entity.delete(this.world, id);
+    },
+
+    cleanup() {
+        this.updateCount = 0;
+    },
+
+    updateMovementSystem() {
+        for (let i = 0; i < this.query.length; i++) {
+            const [e, [p, v]] = this.query[i];
+            for (let j = 0; j < e.length; j++) {
+                p.x[j] += v.x[j];
+                p.y[j] += v.y[j];
+                this.updateCount++;
+            }
+        }
+    },
+
+    getMovementSystemUpdateCount() {
+        return this.updateCount;
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,390 @@
 {
     "name": "js-ecs-benchmarks",
     "version": "1.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "version": "1.0.0",
+            "dependencies": {
+                "ape-ecs": "^1.3.0",
+                "bitecs": "^0.2.14",
+                "ecsy": "^0.4.2",
+                "elegant-spinner": "^2.0.0",
+                "fastecs": "^0.0.3",
+                "geotic": "^4.1.0",
+                "geotic-legacy": "^3.5.5",
+                "goodluck": "^7.0.0",
+                "harmony-ecs": "^0.0.8",
+                "log-update": "^4.0.0",
+                "nano-ecs": "^2.4.0",
+                "perform-ecs": "^0.7.8",
+                "picoes": "^1.0.0",
+                "piecs": "^0.4.0",
+                "tiny-ecs": "^2.0.0",
+                "uecs": "0.1.7",
+                "wolf-ecs": "^2.0.0",
+                "yagl-ecs": "^1.1.0"
+            },
+            "devDependencies": {
+                "prettier": "^2.2.1"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+            "dependencies": {
+                "type-fest": "^0.11.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ape-ecs": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ape-ecs/-/ape-ecs-1.3.0.tgz",
+            "integrity": "sha512-968xe09Kqm6lJh8bL3T99boy2Sut2Ntycd0UEuSxalpMAg83stJPqKCdqqOYgA8iDx6cqPUxeOw2o7SrjPZN+Q=="
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/bitecs": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.2.14.tgz",
+            "integrity": "sha512-c/Md5wu2OGlWtKo5p2Efk9sZyPKZL3aVpei+JBC63m+ucRRPfMsTcoqN5iUN4pKYL/5nakLccq0lP+IMjqXvFA=="
+        },
+        "node_modules/camelcase": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+            "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/ecsy": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/ecsy/-/ecsy-0.4.2.tgz",
+            "integrity": "sha512-dVKOkuz1IsRvS7GlHcWghUtMZzXr70h6b+SQEHlKy2RgsCRNDzdYr6a43Q6HafuquA/67YFZCQt8zqadq/jlLA=="
+        },
+        "node_modules/elegant-spinner": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-2.0.0.tgz",
+            "integrity": "sha512-5YRYHhvhYzV/FC4AiMdeSIg3jAYGq9xFvbhZMpPlJoBsfYgrw2DSCYeXfat6tYBu45PWiyRr3+flaCPPmviPaA==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/fastecs": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/fastecs/-/fastecs-0.0.3.tgz",
+            "integrity": "sha512-WaqKvseOn8BLns8VCJb1upsH4FlFzfUBKZAm9OmMK+h4E/bFbzx+mpBQ/bxncWpfRw3Tl7z9LDWqB4yc35aN7Q=="
+        },
+        "node_modules/geotic": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/geotic/-/geotic-4.1.0.tgz",
+            "integrity": "sha512-JgsJKzagCzC29v2dy0J/Gtsid1+3fmRN6WhX3NXUKYtHM5uDMIsQwP/R00LJFzCIQhyq5YxkXxGulL1B5gILeQ==",
+            "dependencies": {
+                "camelcase": "6.0.0",
+                "nanoid": "3.1.3"
+            }
+        },
+        "node_modules/geotic-legacy": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/geotic-legacy/-/geotic-legacy-3.5.5.tgz",
+            "integrity": "sha512-eJcgP/favflF+O8P0rv3fxyuEoriwfGzM8/i81EWFcFyuR88QfDzWDelyIZNqRuE6ZBDhuxKIO7PQPA0DAlaug==",
+            "dependencies": {
+                "camelcase": "6.0.0",
+                "nanoid": "3.1.3"
+            }
+        },
+        "node_modules/goodluck": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/goodluck/-/goodluck-7.0.0.tgz",
+            "integrity": "sha512-ml0lMI5CGXkSHRg7Po3wpyNm0qMDshrquiXEVFdAYyehvh8qT5SsQuLvK+T6YjUMJE27d1EkqVhNBp1ufsZEZA==",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/harmony-ecs": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/harmony-ecs/-/harmony-ecs-0.0.8.tgz",
+            "integrity": "sha512-ZBmUctizKm7k4RdAkyiFZ1xlQ92rsyTtUx0C0JVmo6ZaLq1kjmr9zAKtqQ1uwOuNuJcMSr9numxQTREpDQU7LQ=="
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/log-update": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+            "dependencies": {
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/nano-ecs": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/nano-ecs/-/nano-ecs-2.4.0.tgz",
+            "integrity": "sha512-joV4lvMWQaxgEzkwpeNCF/R/iOwPXzhFe/Ekc4zZGI0HgurYnoULXEPnxR7yv6QFkQEwoAPx5eEcrT1lbHTSpQ==",
+            "dependencies": {
+                "reuse-pool": "^1.0.2",
+                "typedef": "~1.0.2"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.3.tgz",
+            "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/perform-ecs": {
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/perform-ecs/-/perform-ecs-0.7.8.tgz",
+            "integrity": "sha512-+4WYfCW6/ZVYQDF+78RJc7oWmK2dqtfsdDRfB/kyiHfbQfRIWldJqn2hpQt0ByDWQgtFQrMGGpED1S9wQj3WOw=="
+        },
+        "node_modules/picoes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picoes/-/picoes-1.0.0.tgz",
+            "integrity": "sha512-M930o/vy0zAF55nFjUa8e7ZrU/WTB7jJjQKk2jImMyUkZVHStseUAPXo7STKs+wnzWXGkmUYZjN3qQZXb0+TDg=="
+        },
+        "node_modules/piecs": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/piecs/-/piecs-0.4.0.tgz",
+            "integrity": "sha512-NiGuWHykjFCahsYzn7U3+Q0nk9wUr0wITRioTVCZkK6nk8P4Px/arWYviezyMDT5OaqNmLg4eL00Udj4txlhrQ=="
+        },
+        "node_modules/prettier": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/reuse-pool": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/reuse-pool/-/reuse-pool-1.0.2.tgz",
+            "integrity": "sha1-hPCRVk2N/EagPKeCWss3E3W21Fw="
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tiny-ecs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tiny-ecs/-/tiny-ecs-2.0.0.tgz",
+            "integrity": "sha1-lmuB+UqXXasI1GCmkdYl90wpVBw=",
+            "dependencies": {
+                "typedef": "~1.0.2"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+            "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typedef": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typedef/-/typedef-1.0.4.tgz",
+            "integrity": "sha1-+DOIgWkWBk2UYAjZrrKXyqq/ODs="
+        },
+        "node_modules/uecs": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/uecs/-/uecs-0.1.7.tgz",
+            "integrity": "sha512-fFs6Ive0p9q/hcd7UGnZSudHAHeC3YLI4S3nqG78U+MKdW0AV/fN806kuX7Y+LPMkGAJKphS6qt7J2FFMfpjEA=="
+        },
+        "node_modules/wolf-ecs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/wolf-ecs/-/wolf-ecs-2.0.0.tgz",
+            "integrity": "sha512-7KEps7Nzu0YeHlWZfr0u1ThUYCbgHtxpqkvVxyliEvcMeATyoJJ0oUfGpsILKU7bRqttwy3vYZDm/pBMBxXAlw=="
+        },
+        "node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yagl-ecs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/yagl-ecs/-/yagl-ecs-1.1.0.tgz",
+            "integrity": "sha1-dM1Qe/USpKEqmIYHFAR9/CQaaaY=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        }
+    },
     "dependencies": {
         "ansi-escapes": {
             "version": "4.3.1",
@@ -108,6 +490,11 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/goodluck/-/goodluck-7.0.0.tgz",
             "integrity": "sha512-ml0lMI5CGXkSHRg7Po3wpyNm0qMDshrquiXEVFdAYyehvh8qT5SsQuLvK+T6YjUMJE27d1EkqVhNBp1ufsZEZA=="
+        },
+        "harmony-ecs": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/harmony-ecs/-/harmony-ecs-0.0.8.tgz",
+            "integrity": "sha512-ZBmUctizKm7k4RdAkyiFZ1xlQ92rsyTtUx0C0JVmo6ZaLq1kjmr9zAKtqQ1uwOuNuJcMSr9numxQTREpDQU7LQ=="
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "geotic": "^4.1.0",
         "geotic-legacy": "^3.5.5",
         "goodluck": "^7.0.0",
+        "harmony-ecs": "^0.0.8",
         "log-update": "^4.0.0",
         "nano-ecs": "^2.4.0",
         "perform-ecs": "^0.7.8",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Includes:
 -   [fastecs](https://github.com/octavetoast/fastecs)
 -   [geotic](https://github.com/ddmills/geotic)
 -   [goodluck](https://github.com/piesku/goodluck)
+-   [harmony-ecs](https://github.com/3mcd/harmony-ecs)
 -   [nano-ecs](https://github.com/noffle/nano-ecs)
 -   [perform-ecs](https://github.com/fireveined/perform-ecs)
 -   [piecs](https://github.com/sondresj/piecs)
@@ -22,58 +23,62 @@ Pull requests are welcome! This project uses `node v14.15.4`.
 
 ```
 Suite Add/Remove (5000 iterations)
-  - piecs           17ms     85997ms    25010000 updates       0.0% fastest
-  - bitecs          19ms     97479ms    25010000 updates      13.4% slower
-  - wolf-ecs        24ms    118929ms    25010000 updates      38.3% slower
-  - perform-ecs     49ms    242549ms    25010000 updates     182.0% slower
-  - uecs            53ms    263894ms    25010000 updates     206.9% slower
-  - geotic (v4)     69ms    346180ms    25010000 updates     302.5% slower
-  - goodluck        88ms    439731ms    25010000 updates     411.3% slower
-  - picoes         122ms    611264ms    25010000 updates     610.8% slower
-  - yagl-ecs       126ms    631975ms    25010000 updates     634.9% slower
-  - tiny-ecs       137ms    683664ms    25010000 updates     695.0% slower
-  - nano-ecs       188ms    940590ms    25010000 updates     993.7% slower
-  - ape-ecs        433ms   2166425ms    25010000 updates    2419.2% slower
+  - piecs           14ms     71968ms    25010000 updates       0.0% fastest
+  - bitecs          17ms     84746ms    25010000 updates      17.8% slower
+  - harmony-ecs     17ms     86495ms    25010000 updates      20.2% slower
+  - wolf-ecs        23ms    113042ms    25010000 updates      57.1% slower
+  - perform-ecs     39ms    192871ms    25010000 updates     168.0% slower
+  - uecs            40ms    198229ms    25010000 updates     175.4% slower
+  - geotic (v4)     58ms    291495ms    25010000 updates     305.0% slower
+  - goodluck        68ms    339004ms    25010000 updates     371.1% slower
+  - yagl-ecs        69ms    342712ms    25010000 updates     376.2% slower
+  - picoes         106ms    532021ms    25010000 updates     639.2% slower
+  - tiny-ecs       117ms    586515ms    25010000 updates     715.0% slower
+  - nano-ecs       156ms    781924ms    25010000 updates     986.5% slower
+  - ape-ecs        335ms   1675963ms    25010000 updates    2228.8% slower
 
 Suite Additions (100000 iterations)
-  - goodluck         0ms     33669ms       0.0% fastest
-  - bitecs           0ms     39437ms      17.1% slower
-  - piecs            0ms     40589ms      20.6% slower
-  - wolf-ecs         0ms     48079ms      42.8% slower
-  - yagl-ecs         1ms     60380ms      79.3% slower
-  - picoes           1ms    103972ms     208.8% slower
-  - uecs             1ms    118209ms     251.1% slower
-  - tiny-ecs         1ms    123275ms     266.1% slower
-  - nano-ecs         2ms    158318ms     370.2% slower
-  - geotic (v4)      2ms    236220ms     601.6% slower
-  - perform-ecs      3ms    254568ms     656.1% slower
-  - ape-ecs          5ms    472577ms    1303.6% slower
+  - bitecs           0ms     16230ms       0.0% fastest
+  - goodluck         0ms     20996ms      29.4% slower
+  - wolf-ecs         0ms     27706ms      70.7% slower
+  - yagl-ecs         0ms     36289ms     123.6% slower
+  - piecs            0ms     39417ms     142.9% slower
+  - picoes           1ms     83357ms     413.6% slower
+  - harmony-ecs      1ms     90800ms     459.5% slower
+  - uecs             1ms     94242ms     480.7% slower
+  - nano-ecs         1ms    120185ms     640.5% slower
+  - geotic (v4)      2ms    188178ms    1059.5% slower
+  - perform-ecs      2ms    212519ms    1209.4% slower
+  - tiny-ecs         3ms    304099ms    1773.7% slower
+  - ape-ecs          5ms    518898ms    3097.2% slower
 
 Suite Destroy (100000 iterations)
-  - goodluck         0ms     16580ms       0.0% fastest
-  - piecs            0ms     29462ms      77.7% slower
-  - wolf-ecs         0ms     34914ms     110.6% slower
-  - bitecs           1ms     81781ms     393.2% slower
-  - picoes           1ms    124334ms     649.9% slower
-  - uecs             2ms    176154ms     962.4% slower
-  - tiny-ecs         2ms    181783ms     996.4% slower
-  - nano-ecs         2ms    236698ms    1327.6% slower
-  - perform-ecs      2ms    248207ms    1397.0% slower
-  - geotic (v4)      5ms    498395ms    2905.9% slower
-  - ape-ecs          5ms    539826ms    3155.8% slower
-  - yagl-ecs        19ms   1890954ms   11304.7% slower
+  - goodluck         0ms      9183ms       0.0% fastest
+  - piecs            0ms     15655ms      70.5% slower
+  - wolf-ecs         0ms     23069ms     151.2% slower
+  - harmony-ecs      1ms     74844ms     715.1% slower
+  - picoes           1ms     91232ms     893.5% slower
+  - bitecs           1ms    107783ms    1073.8% slower
+  - tiny-ecs         1ms    137011ms    1392.1% slower
+  - uecs             1ms    144825ms    1477.2% slower
+  - nano-ecs         2ms    171021ms    1762.5% slower
+  - perform-ecs      2ms    206078ms    2144.3% slower
+  - ape-ecs          4ms    404518ms    4305.3% slower
+  - geotic (v4)      5ms    511684ms    5472.4% slower
+  - yagl-ecs        18ms   1756009ms   19023.4% slower
 
 Suite Velocity (2000 iterations)
-  - wolf-ecs         5ms     10748ms     2001000 updates       0.0% fastest
-  - piecs            6ms     12313ms     2001000 updates      14.6% slower
-  - uecs            11ms     21940ms     2001000 updates     104.1% slower
-  - perform-ecs     11ms     22200ms     2001000 updates     106.6% slower
-  - goodluck        13ms     26993ms     2001000 updates     151.2% slower
-  - tiny-ecs        14ms     28744ms     2001000 updates     167.4% slower
-  - geotic (v4)     17ms     33644ms     2001000 updates     213.0% slower
-  - nano-ecs        20ms     39010ms     2001000 updates     263.0% slower
-  - yagl-ecs        24ms     47132ms     2001000 updates     338.5% slower
-  - picoes          28ms     56641ms     2001000 updates     427.0% slower
-  - bitecs          58ms    115608ms     2001000 updates     975.7% slower
-  - ape-ecs         97ms    194574ms     2001000 updates    1710.4% slower
+  - harmony-ecs      5ms      9433ms     2001000 updates       0.0% fastest
+  - wolf-ecs         5ms     10773ms     2001000 updates      14.2% slower
+  - piecs            6ms     11879ms     2001000 updates      25.9% slower
+  - bitecs           8ms     15636ms     2001000 updates      65.7% slower
+  - perform-ecs      8ms     16403ms     2001000 updates      73.9% slower
+  - uecs             9ms     18086ms     2001000 updates      91.7% slower
+  - tiny-ecs        12ms     24069ms     2001000 updates     155.1% slower
+  - yagl-ecs        14ms     28956ms     2001000 updates     206.9% slower
+  - nano-ecs        18ms     35913ms     2001000 updates     280.7% slower
+  - goodluck        26ms     52284ms     2001000 updates     454.2% slower
+  - picoes          28ms     56308ms     2001000 updates     496.9% slower
+  - geotic (v4)     43ms     86331ms     2001000 updates     815.2% slower
+  - ape-ecs         76ms    151416ms     2001000 updates    1505.1% slower
 ```


### PR DESCRIPTION
Hey @ddmills. Another one, lol

The report here was chosen (kind of) empirically but I assume the benchmarks may paint a different picture on other machines. Similar to @sondresj's PR for piecs, I ran the suite several times until I got a feel for the average variance on my machine and chose a report that deviated from the existing results _the least_. Harmony places consistently at the top for the "Suite Velocity" suite and consistently below others (goodluck, wolf-ecs, bitecs, piecs) in the other suites.

Thanks for maintaining this benchmark. I like your test fixture/abstraction a lot. It made it super easy to add a new library.